### PR TITLE
EM-1145

### DIFF
--- a/docker-compose-dependencies.yml
+++ b/docker-compose-dependencies.yml
@@ -9,7 +9,6 @@ services:
 #      - Add key for any microservice that will be used: template-management
       - microserviceKeys_em_gw=AAAAAAAAAAAAAAAA
       - microserviceKeys_dg_docassembly_api=AAAAAAAAAAAAAAAA
-      - microserviceKeys_dg_template_management_api=AAAAAAAAAAAAAAAA
       #      logging env vars
       - JSON_CONSOLE_PRETTY_PRINT=false
       - REFORM_SERVICE_TYPE=java
@@ -68,19 +67,6 @@ services:
       - POSTGRES_DB=idam
     ports:
       - 5434:5432
-
-  rpa-dg-template-management-api:
-    image: hmcts.azurecr.io/hmcts/dg-tmpl-mgmt:latest
-    environment:
-      - S2S_BASE_URI=http://service-auth-provider-app:8489
-      - IDAM_API_BASE_URI=http://idam-api:8080
-      - APPINSIGHTS_INSTRUMENTATIONKEY=test-key
-    links:
-      - service-auth-provider-app
-    depends_on:
-      - service-auth-provider-app
-    ports:
-      - 4630:8080
 
   dm-store:
     image: hmcts/dm-store:latest

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -75,8 +75,12 @@ module "app" {
     ENABLE_S2S_HEALTH_CHECK = "${var.enable_s2s_healthcheck}"
 
     DM_STORE_APP_URL = "http://${var.dm_store_app_url}-${local.local_env}.service.core-compute-${local.local_env}.internal"
-    DG_TEMPLATE_MANAGEMENT_API = "http://${var.dg_template_management_api}-${local.local_env}.service.core-compute-${local.local_env}.internal"
+
+    DOCMOSIS_ENDPOINT = "${var.docmosis_uri}"
     DOCMOSIS_ACCESS_KEY = "${data.azurerm_key_vault_secret.docmosis_access_key.value}"
+
+    DOCMOSIS_TEMPLATES_ENDPOINT = "${var.docmosis_templates_uri}"
+    DOCMOSIS_TEMPLATES_ENDPOINT_AUTH = "${data.azurerm_key_vault_secret.docmosis_templates_auth.value}"
   }
 }
 
@@ -98,6 +102,11 @@ provider "vault" {
 
 data "azurerm_key_vault_secret" "docmosis_access_key" {
   name      = "docmosis-access-key"
+  vault_uri = "https://rpa-${local.local_env}.vault.azure.net/"
+}
+
+data "azurerm_key_vault_secret" "docmosis_templates_auth" {
+  name      = "docmosis-templates-auth"
   vault_uri = "https://rpa-${local.local_env}.vault.azure.net/"
 }
 

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -65,6 +65,14 @@ variable "s2s_name" {
   default = "rpe-service-auth-provider"
 }
 
+variable "docmosis_uri" {
+  default = "https://docmosis-development.platform.hmcts.net/rs/render"
+}
+
+variable "docmosis_templates_uri" {
+  default = "https://docmosis-development.platform.hmcts.net"
+}
+
 ////////////////////////////////////////////////
 // Logging
 ////////////////////////////////////////////////

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -64,8 +64,9 @@ idam:
     microservice: dg_docassembly_api
 
 template-management-api:
-  base-url: ${DG_TEMPLATE_MANAGEMENT_API:http://localhost:4630}
-  resource: '/api/templates'
+  base-url: ${DOCMOSIS_TEMPLATES_ENDPOINT:https://docmosis-development.platform.hmcts.net}
+  auth: ${DOCMOSIS_TEMPLATES_ENDPOINT_AUTH:SOMETHING}
+  resource: '/templates/'
 
 docmosis:
   accessKey: ${DOCMOSIS_ACCESS_KEY:SOMETHING}

--- a/src/test/java/uk/gov/hmcts/reform/dg/docassembly/service/TemplateManagementApiClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/dg/docassembly/service/TemplateManagementApiClientTest.java
@@ -30,8 +30,9 @@ public class TemplateManagementApiClientTest {
         authTokenGenerator = Mockito.mock(AuthTokenGenerator.class);
 
         templateManagementApiClient = new TemplateManagementApiClient(
-                authTokenGenerator,
-                client, "http://template-management-api/templates");
+                client,
+                "http://template-management-api/templates/",
+                "xxx");
     }
 
 
@@ -40,7 +41,7 @@ public class TemplateManagementApiClientTest {
         TemplateIdDto templateIdDto = new TemplateIdDto();
 
         templateIdDto.setJwt("x");
-        templateIdDto.setTemplateId("abc");
+        templateIdDto.setTemplateId("YWJj");
 
         Mockito.when(authTokenGenerator.generate()).thenReturn("x");
 
@@ -58,7 +59,7 @@ public class TemplateManagementApiClientTest {
         TemplateIdDto templateIdDto = new TemplateIdDto();
 
         templateIdDto.setJwt("x");
-        templateIdDto.setTemplateId("abc");
+        templateIdDto.setTemplateId("YWJj");
 
         Mockito.when(authTokenGenerator.generate()).thenReturn("x");
 
@@ -77,7 +78,7 @@ public class TemplateManagementApiClientTest {
         TemplateIdDto templateIdDto = new TemplateIdDto();
 
         templateIdDto.setJwt("x");
-        templateIdDto.setTemplateId("abc");
+        templateIdDto.setTemplateId("YWJj");
 
         Mockito.when(authTokenGenerator.generate()).thenReturn("x");
 


### PR DESCRIPTION
changed the implementation of Doc Assembly to use templates endpoints provided by devops.

https://github.com/hmcts/rpa-dg-template-management-api API will be no longer used as a dependency (for now)

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/EM-1145

### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
