### PR TITLE
Added input validation on the setting of a JWT Token to check it conf…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'application'
     id 'io.spring.dependency-management' version '1.0.8.RELEASE'
     id 'org.springframework.boot' version '2.1.6.RELEASE'
-    id 'org.owasp.dependencycheck' version '5.1.0'
+    id 'org.owasp.dependencycheck' version '5.2.1'
     id 'com.github.ben-manes.versions' version '0.21.0'
     id "se.patrikerdes.use-latest-versions" version "0.2.11"
     id 'org.sonarqube' version '2.7.1'
@@ -46,7 +46,7 @@ dependencies {
     compile "com.squareup.okhttp3:okhttp:4.0.1"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-json-org:2.9.9"
     compile "com.fasterxml.jackson.core:jackson-annotations:2.9.9"
-    compile "com.fasterxml.jackson.core:jackson-databind:2.9.9.1"
+    compile "com.fasterxml.jackson.core:jackson-databind:2.9.9.2"
     compile "com.fasterxml.jackson.module:jackson-module-afterburner:2.9.9"
     compile "com.jayway.jsonpath:json-path:2.4.0"
     compile "io.springfox:springfox-swagger2:2.9.2"

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     compile "com.squareup.okhttp3:okhttp:4.0.1"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-json-org:2.9.9"
     compile "com.fasterxml.jackson.core:jackson-annotations:2.9.9"
-    compile "com.fasterxml.jackson.core:jackson-databind:2.9.9.3"
+    compile "com.fasterxml.jackson.core:jackson-databind:2.9.9.1"
     compile "com.fasterxml.jackson.module:jackson-module-afterburner:2.9.9"
     compile "com.jayway.jsonpath:json-path:2.4.0"
     compile "io.springfox:springfox-swagger2:2.9.2"

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     compile "com.squareup.okhttp3:okhttp:4.0.1"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-json-org:2.9.9"
     compile "com.fasterxml.jackson.core:jackson-annotations:2.9.9"
-    compile "com.fasterxml.jackson.core:jackson-databind:2.9.9.2"
+    compile "com.fasterxml.jackson.core:jackson-databind:2.9.9.3"
     compile "com.fasterxml.jackson.module:jackson-module-afterburner:2.9.9"
     compile "com.jayway.jsonpath:json-path:2.4.0"
     compile "io.springfox:springfox-swagger2:2.9.2"

--- a/config/owasp/dependency-check-suppressions.xml
+++ b/config/owasp/dependency-check-suppressions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
     <suppress>
         <notes>No newer release available</notes>
         <cve>CVE-2019-9658</cve>
@@ -18,5 +18,15 @@
         <cve>CVE-2019-11358</cve>
         <cve>CVE-2016-7103</cve>
         <cve>CVE-2010-5312</cve>
+        <cve>CVE-2019-14379</cve>
+        <cve>CVE-2019-14439</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+            file name: gatling-charts-3.0.0.jar: moment.min.js
+            ]]>
+        </notes>
+        <packageUrl regex="true">^pkg:javascript/moment\.js@.*$</packageUrl>
+        <vulnerabilityName>reDOS - regular expression denial of service</vulnerabilityName>
     </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/reform/dg/docassembly/dto/JwtDto.java
+++ b/src/main/java/uk/gov/hmcts/reform/dg/docassembly/dto/JwtDto.java
@@ -9,13 +9,6 @@ public class JwtDto {
     }
 
     public void setJwt(String jwt) {
-        // Avoid non JWT Tokens being set from the header (Fix for SonarCloud https://sonarcloud.io/organizations/hmcts/rules?open=javasecurity%3AS2083&rule_key=javasecurity%3AS2083)
-//        if (jwt.matches("^[A-Za-z0-9-_=]+\\.[A-Za-z0-9-_=]+\\.?[A-Za-z0-9-_.+/=]*$")) {
-//            this.jwt = jwt;
-//        } else {
-//            this.jwt = "";
-//        }
-        // TEMPORARY FOR DEBUG!
         this.jwt = jwt;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/dg/docassembly/dto/JwtDto.java
+++ b/src/main/java/uk/gov/hmcts/reform/dg/docassembly/dto/JwtDto.java
@@ -10,10 +10,12 @@ public class JwtDto {
 
     public void setJwt(String jwt) {
         // Avoid non JWT Tokens being set from the header (Fix for SonarCloud https://sonarcloud.io/organizations/hmcts/rules?open=javasecurity%3AS2083&rule_key=javasecurity%3AS2083)
-        if (jwt.matches("^[A-Za-z0-9-_=]+\\.[A-Za-z0-9-_=]+\\.?[A-Za-z0-9-_.+/=]*$")) {
-            this.jwt = jwt;
-        } else {
-            this.jwt = "";
-        }
+//        if (jwt.matches("^[A-Za-z0-9-_=]+\\.[A-Za-z0-9-_=]+\\.?[A-Za-z0-9-_.+/=]*$")) {
+//            this.jwt = jwt;
+//        } else {
+//            this.jwt = "";
+//        }
+        // TEMPORARY FOR DEBUG!
+        this.jwt = jwt;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/dg/docassembly/dto/JwtDto.java
+++ b/src/main/java/uk/gov/hmcts/reform/dg/docassembly/dto/JwtDto.java
@@ -10,7 +10,7 @@ public class JwtDto {
 
     public void setJwt(String jwt) {
         // Avoid non JWT Tokens being set from the header (Fix for SonarCloud https://sonarcloud.io/organizations/hmcts/rules?open=javasecurity%3AS2083&rule_key=javasecurity%3AS2083)
-        if(jwt.matches("^[A-Za-z0-9-_=]+\\.[A-Za-z0-9-_=]+\\.?[A-Za-z0-9-_.+/=]*$")){
+        if (jwt.matches("^[A-Za-z0-9-_=]+\\.[A-Za-z0-9-_=]+\\.?[A-Za-z0-9-_.+/=]*$")) {
             this.jwt = jwt;
         } else {
             this.jwt = "";

--- a/src/main/java/uk/gov/hmcts/reform/dg/docassembly/dto/JwtDto.java
+++ b/src/main/java/uk/gov/hmcts/reform/dg/docassembly/dto/JwtDto.java
@@ -9,6 +9,12 @@ public class JwtDto {
     }
 
     public void setJwt(String jwt) {
-        this.jwt = jwt;
+        // Avoid Tokens being set from the header without validation (Fix for SonarCloud https://sonarcloud.io/organizations/hmcts/rules?open=javasecurity%3AS2083&rule_key=javasecurity%3AS2083)
+        // This object does not hold a true JWT Token, but it does hold a Base64 encoded string, thus, if it is Base64 encoded, we allow it through.
+        if(jwt.matches("^[A-Za-z0-9-_.+/=]+$")){
+            this.jwt = jwt;
+        } else {
+            this.jwt = "";
+        }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/dg/docassembly/dto/JwtDto.java
+++ b/src/main/java/uk/gov/hmcts/reform/dg/docassembly/dto/JwtDto.java
@@ -11,7 +11,7 @@ public class JwtDto {
     public void setJwt(String jwt) {
         // Avoid Tokens being set from the header without validation (Fix for SonarCloud https://sonarcloud.io/organizations/hmcts/rules?open=javasecurity%3AS2083&rule_key=javasecurity%3AS2083)
         // This object does not hold a true JWT Token, but it does hold a Base64 encoded string, thus, if it is Base64 encoded, we allow it through.
-        if(jwt.matches("^[A-Za-z0-9-_.+/=]+$")){
+        if (jwt.matches("^[A-Za-z0-9-_.+/=]+$")) {
             this.jwt = jwt;
         } else {
             this.jwt = "";

--- a/src/main/java/uk/gov/hmcts/reform/dg/docassembly/dto/JwtDto.java
+++ b/src/main/java/uk/gov/hmcts/reform/dg/docassembly/dto/JwtDto.java
@@ -9,6 +9,11 @@ public class JwtDto {
     }
 
     public void setJwt(String jwt) {
-        this.jwt = jwt;
+        // Avoid non JWT Tokens being set from the header (Fix for SonarCloud https://sonarcloud.io/organizations/hmcts/rules?open=javasecurity%3AS2083&rule_key=javasecurity%3AS2083)
+        if(jwt.matches("^[A-Za-z0-9-_=]+\\.[A-Za-z0-9-_=]+\\.?[A-Za-z0-9-_.+/=]*$")){
+            this.jwt = jwt;
+        } else {
+            this.jwt = "";
+        }
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/dg/docassembly/rest/FormDefinitionResourceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/dg/docassembly/rest/FormDefinitionResourceTest.java
@@ -64,7 +64,7 @@ public class FormDefinitionResourceTest {
 
         this.mockMvc
                 .perform(get("/api/form-definitions/123")
-                        .header("Authorization", "xxx")
+                        .header("Authorization", "x.y.z")
                         .header("ServiceAuthorization", "xxx"))
                 .andDo(print()).andExpect(status().isOk());
 
@@ -86,7 +86,7 @@ public class FormDefinitionResourceTest {
 
         this.mockMvc
                 .perform(get("/api/form-definitions/123")
-                        .header("Authorization", "xxx")
+                        .header("Authorization", "x.y.z")
                         .header("ServiceAuthorization", "xxx"))
                 .andDo(print()).andExpect(status().is4xxClientError());
 
@@ -109,7 +109,7 @@ public class FormDefinitionResourceTest {
 
         this.mockMvc
                 .perform(get("/api/form-definitions/123")
-                        .header("Authorization", "xxx")
+                        .header("Authorization", "x.y.z")
                         .header("ServiceAuthorization", "xxx"))
                 .andDo(print()).andExpect(status().is5xxServerError());
 

--- a/src/test/java/uk/gov/hmcts/reform/dg/docassembly/service/DmStoreUploaderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/dg/docassembly/service/DmStoreUploaderTest.java
@@ -51,15 +51,15 @@ public class DmStoreUploaderTest {
     @Test
     public void testUploadNewFile() throws Exception {
         CreateTemplateRenditionDto createTemplateRenditionDto = new CreateTemplateRenditionDto();
-        createTemplateRenditionDto.setJwt("x");
+        createTemplateRenditionDto.setJwt("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c");
         createTemplateRenditionDto.setTemplateId(new String(Base64.getEncoder().encode("1".getBytes())));
         createTemplateRenditionDto.setOutputType(RenditionOutputType.PDF);
         createTemplateRenditionDto.setFormPayload(objectMapper.readTree("{}"));
-        Mockito.when(authTokenGenerator.generate()).thenReturn("x");
+        Mockito.when(authTokenGenerator.generate()).thenReturn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c");
 
         User mockedUser = Mockito.mock(User.class);
         Mockito.when(mockedUser.getPrincipal()).thenReturn("p1");
-        Mockito.when(userResolver.getTokenDetails("x")).thenReturn(mockedUser);
+        Mockito.when(userResolver.getTokenDetails("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")).thenReturn(mockedUser);
 
         interceptor.addRule(new Rule.Builder()
                 .post()
@@ -76,15 +76,15 @@ public class DmStoreUploaderTest {
     @Test(expected = DocumentUploaderException.class)
     public void testUploadNewFileHttpFailedException() throws Exception {
         CreateTemplateRenditionDto createTemplateRenditionDto = new CreateTemplateRenditionDto();
-        createTemplateRenditionDto.setJwt("x");
+        createTemplateRenditionDto.setJwt("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c");
         createTemplateRenditionDto.setTemplateId(new String(Base64.getEncoder().encode("1".getBytes())));
         createTemplateRenditionDto.setOutputType(RenditionOutputType.PDF);
         createTemplateRenditionDto.setFormPayload(objectMapper.readTree("{}"));
-        Mockito.when(authTokenGenerator.generate()).thenReturn("x");
+        Mockito.when(authTokenGenerator.generate()).thenReturn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c");
 
         User mockedUser = Mockito.mock(User.class);
         Mockito.when(mockedUser.getPrincipal()).thenReturn("p1");
-        Mockito.when(userResolver.getTokenDetails("x")).thenReturn(mockedUser);
+        Mockito.when(userResolver.getTokenDetails("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")).thenReturn(mockedUser);
 
         interceptor.addRule(new Rule.Builder()
                 .post()
@@ -97,16 +97,16 @@ public class DmStoreUploaderTest {
     @Test
     public void testUploadNewVersionOfFile() throws Exception {
         CreateTemplateRenditionDto createTemplateRenditionDto = new CreateTemplateRenditionDto();
-        createTemplateRenditionDto.setJwt("x");
+        createTemplateRenditionDto.setJwt("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c");
         createTemplateRenditionDto.setTemplateId(new String(Base64.getEncoder().encode("1".getBytes())));
         createTemplateRenditionDto.setOutputType(RenditionOutputType.PDF);
         createTemplateRenditionDto.setFormPayload(objectMapper.readTree("{}"));
         createTemplateRenditionDto.setRenditionOutputLocation("http://success.com/1");
-        Mockito.when(authTokenGenerator.generate()).thenReturn("x");
+        Mockito.when(authTokenGenerator.generate()).thenReturn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c");
 
         User mockedUser = Mockito.mock(User.class);
         Mockito.when(mockedUser.getPrincipal()).thenReturn("p1");
-        Mockito.when(userResolver.getTokenDetails("x")).thenReturn(mockedUser);
+        Mockito.when(userResolver.getTokenDetails("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")).thenReturn(mockedUser);
 
         interceptor.addRule(new Rule.Builder()
                 .post()
@@ -124,16 +124,16 @@ public class DmStoreUploaderTest {
     @Test(expected = DocumentUploaderException.class)
     public void testUploadNewVersionOfFileException() throws Exception {
         CreateTemplateRenditionDto createTemplateRenditionDto = new CreateTemplateRenditionDto();
-        createTemplateRenditionDto.setJwt("x");
+        createTemplateRenditionDto.setJwt("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c");
         createTemplateRenditionDto.setTemplateId(new String(Base64.getEncoder().encode("1".getBytes())));
         createTemplateRenditionDto.setOutputType(RenditionOutputType.PDF);
         createTemplateRenditionDto.setFormPayload(objectMapper.readTree("{}"));
         createTemplateRenditionDto.setRenditionOutputLocation("http://success.com/1");
-        Mockito.when(authTokenGenerator.generate()).thenReturn("x");
+        Mockito.when(authTokenGenerator.generate()).thenReturn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c");
 
         User mockedUser = Mockito.mock(User.class);
         Mockito.when(mockedUser.getPrincipal()).thenReturn("p1");
-        Mockito.when(userResolver.getTokenDetails("x")).thenReturn(mockedUser);
+        Mockito.when(userResolver.getTokenDetails("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")).thenReturn(mockedUser);
 
         interceptor.addRule(new Rule.Builder()
                 .post()

--- a/src/test/java/uk/gov/hmcts/reform/dg/docassembly/service/DmStoreUploaderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/dg/docassembly/service/DmStoreUploaderTest.java
@@ -51,15 +51,15 @@ public class DmStoreUploaderTest {
     @Test
     public void testUploadNewFile() throws Exception {
         CreateTemplateRenditionDto createTemplateRenditionDto = new CreateTemplateRenditionDto();
-        createTemplateRenditionDto.setJwt("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c");
+        createTemplateRenditionDto.setJwt("x.y.z");
         createTemplateRenditionDto.setTemplateId(new String(Base64.getEncoder().encode("1".getBytes())));
         createTemplateRenditionDto.setOutputType(RenditionOutputType.PDF);
         createTemplateRenditionDto.setFormPayload(objectMapper.readTree("{}"));
-        Mockito.when(authTokenGenerator.generate()).thenReturn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c");
+        Mockito.when(authTokenGenerator.generate()).thenReturn("x.y.z");
 
         User mockedUser = Mockito.mock(User.class);
         Mockito.when(mockedUser.getPrincipal()).thenReturn("p1");
-        Mockito.when(userResolver.getTokenDetails("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")).thenReturn(mockedUser);
+        Mockito.when(userResolver.getTokenDetails("x.y.z")).thenReturn(mockedUser);
 
         interceptor.addRule(new Rule.Builder()
                 .post()
@@ -76,15 +76,15 @@ public class DmStoreUploaderTest {
     @Test(expected = DocumentUploaderException.class)
     public void testUploadNewFileHttpFailedException() throws Exception {
         CreateTemplateRenditionDto createTemplateRenditionDto = new CreateTemplateRenditionDto();
-        createTemplateRenditionDto.setJwt("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c");
+        createTemplateRenditionDto.setJwt("x.y.z");
         createTemplateRenditionDto.setTemplateId(new String(Base64.getEncoder().encode("1".getBytes())));
         createTemplateRenditionDto.setOutputType(RenditionOutputType.PDF);
         createTemplateRenditionDto.setFormPayload(objectMapper.readTree("{}"));
-        Mockito.when(authTokenGenerator.generate()).thenReturn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c");
+        Mockito.when(authTokenGenerator.generate()).thenReturn("x.y.z");
 
         User mockedUser = Mockito.mock(User.class);
         Mockito.when(mockedUser.getPrincipal()).thenReturn("p1");
-        Mockito.when(userResolver.getTokenDetails("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")).thenReturn(mockedUser);
+        Mockito.when(userResolver.getTokenDetails("x.y.z")).thenReturn(mockedUser);
 
         interceptor.addRule(new Rule.Builder()
                 .post()
@@ -97,16 +97,16 @@ public class DmStoreUploaderTest {
     @Test
     public void testUploadNewVersionOfFile() throws Exception {
         CreateTemplateRenditionDto createTemplateRenditionDto = new CreateTemplateRenditionDto();
-        createTemplateRenditionDto.setJwt("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c");
+        createTemplateRenditionDto.setJwt("x.y.z");
         createTemplateRenditionDto.setTemplateId(new String(Base64.getEncoder().encode("1".getBytes())));
         createTemplateRenditionDto.setOutputType(RenditionOutputType.PDF);
         createTemplateRenditionDto.setFormPayload(objectMapper.readTree("{}"));
         createTemplateRenditionDto.setRenditionOutputLocation("http://success.com/1");
-        Mockito.when(authTokenGenerator.generate()).thenReturn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c");
+        Mockito.when(authTokenGenerator.generate()).thenReturn("x.y.z");
 
         User mockedUser = Mockito.mock(User.class);
         Mockito.when(mockedUser.getPrincipal()).thenReturn("p1");
-        Mockito.when(userResolver.getTokenDetails("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")).thenReturn(mockedUser);
+        Mockito.when(userResolver.getTokenDetails("x.y.z")).thenReturn(mockedUser);
 
         interceptor.addRule(new Rule.Builder()
                 .post()
@@ -124,16 +124,16 @@ public class DmStoreUploaderTest {
     @Test(expected = DocumentUploaderException.class)
     public void testUploadNewVersionOfFileException() throws Exception {
         CreateTemplateRenditionDto createTemplateRenditionDto = new CreateTemplateRenditionDto();
-        createTemplateRenditionDto.setJwt("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c");
+        createTemplateRenditionDto.setJwt("x.y.z");
         createTemplateRenditionDto.setTemplateId(new String(Base64.getEncoder().encode("1".getBytes())));
         createTemplateRenditionDto.setOutputType(RenditionOutputType.PDF);
         createTemplateRenditionDto.setFormPayload(objectMapper.readTree("{}"));
         createTemplateRenditionDto.setRenditionOutputLocation("http://success.com/1");
-        Mockito.when(authTokenGenerator.generate()).thenReturn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c");
+        Mockito.when(authTokenGenerator.generate()).thenReturn("x.y.z");
 
         User mockedUser = Mockito.mock(User.class);
         Mockito.when(mockedUser.getPrincipal()).thenReturn("p1");
-        Mockito.when(userResolver.getTokenDetails("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")).thenReturn(mockedUser);
+        Mockito.when(userResolver.getTokenDetails("x.y.z")).thenReturn(mockedUser);
 
         interceptor.addRule(new Rule.Builder()
                 .post()


### PR DESCRIPTION
…orms to a JWT structure. This is to tackle the SonarQube analysis that a downstream call is reliant on a User provided value... tried testing with a local SonarQube, but cannot recreate the alert, so this may not work when testing with SonarCloud